### PR TITLE
Update Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,12 @@ You can build DRAT in a few steps:
 1. `mkdir -p /usr/local/drat/deploy`
 2. `mkdir -p /usr/local/drat/src`
 3. `cd /usr/local/drat/src`
-4. `git clone https://github.com/chrismattmann/drat.git`
-5. `cd drat`
-6. `mvn install`
-7. `cp -R distribution/target/dms-distribution-0.1-bin.tar.gz ../../deploy`
-8. `cd ../../deploy`
-9. `tar xvzf dms-distribution-0.1-bin.tar.gz`
-10. `rm -rf *.tar.gz`
+4. `git clone https://github.com/chrismattmann/drat.git .`
+5. `mvn install`
+6. `cp -R distribution/target/dms-distribution-0.1-bin.tar.gz ../deploy/`
+7. `cd ../deploy/`
+8. `tar xvzf dms-distribution-0.1-bin.tar.gz`
+9. `rm *.tar.gz`
 
 How to Run
 ===

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ You can build DRAT in a few steps:
 
 1. `mkdir -p /usr/local/drat/deploy`
 2. `mkdir -p /usr/local/drat/src`
-3. `cd /usr/local/drat/`
+3. `cd /usr/local/drat/src`
 4. `git clone https://github.com/chrismattmann/drat.git`
-5. `mv drat src && cd src`
+5. `cd drat`
 6. `mvn install`
-7. `cp -R target/distribution/dms-distribution-0.1-bin.tar.gz deploy`
-8. `cd deploy`
+7. `cp -R distribution/target/dms-distribution-0.1-bin.tar.gz ../../deploy`
+8. `cd ../../deploy`
 9. `tar xvzf dms-distribution-0.1-bin.tar.gz`
 10. `rm -rf *.tar.gz`
 
@@ -34,7 +34,7 @@ Here are the basic commands to run DRAT. Imagine you had a code repo, your-repo,
 2. Start Apache&trade; OODT  
    `cd $DRAT_HOME`  
    `cd filemgr/bin && ./filemgr start`  
-   `cd ../../workflowbin/ && ./wmgr start`  
+   `cd ../../workflow/bin/ && ./wmgr start`  
 
 3. Crawl the repository of interest, e.g., `$HOME/your-repo`:  
     `cd $DRAT_HOME/crawler/bin`  

--- a/extensions/src/main/resources/extractors/code/default.cpr.conf
+++ b/extensions/src/main/resources/extractors/code/default.cpr.conf
@@ -18,7 +18,7 @@
 # to not rewrite any fields in an original metadata file located at [XDATA_HOME]/extractor/kiva_journalentries_aggregate/default.met.xml
 
 numRewriteFields=0
-orig.met.file.path=/usr/local/xdata-code-audit/deploy/extractors/code/default.met.xml
+orig.met.file.path=[DRAT_HOME]/extractors/code/default.met.xml
 
 
 


### PR DESCRIPTION
The instructions have a few directory quirks and the default metadata conf file used a hard-coded path, instead of the DRAT_HOME variable. So, nothing could get crawled.
