### PR TITLE
Update PgeConfig_Rat.xml

### DIFF
--- a/pge/src/main/resources/config/PgeConfig_Rat.xml
+++ b/pge/src/main/resources/config/PgeConfig_Rat.xml
@@ -6,7 +6,7 @@
   <exe dir="[JobDir]" shell="/bin/bash">
      <cmd>export PATH=$HOME/bin/:${PATH}</cmd>
      <cmd>shopt -s expand_aliases</cmd>
-     <cmd>alias rat="java -jar [DRAT_HOME]/rat/lib/apache-rat-0.9.jar"</cmd>
+     <cmd>alias rat="java -jar [DRAT_HOME]/rat/lib/apache-rat-0.11.jar"</cmd>
      <cmd>echo "Creating working dirs"</cmd>
      <cmd>mkdir [JobInputDir] ; mkdir [JobOutputDir]; mkdir [JobLogDir]</cmd>
      <cmd>echo "Staging input to [JobInputDir]"</cmd>


### PR DESCRIPTION
Line 9: version of apache-rat has been changed from 0.9 to 0.11
In the $DRAT_HOME/rat/lib, there exists apache-rat-0.11.jar not apache-rat-0.9.jar as written in the PgeConfig_Rat.xml

Check dependency of apache-rat drat/rat/pom.xml:
  dependencies
 dependency
groupId org.apache.rat /groupId
artifactId apache-rat /artifactId
 version 0.11 /version
 /dependency 
/dependencies
