### PR TITLE
 Upgrade to OODT 0.10 #45

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <oodt.version>0.8</oodt.version>
+    <oodt.version>0.10</oodt.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Hi @chrismattmann 
I don't know what to say about this PR apart from... it was fairly easy :)
DRAT master with this patch run over recent Apache HTrace 4.1.0-incubating release candidate. Ran flawlessly. I checked the build deployment and OODT dependencies are successfully upgraded across the board. OPSUI works very well.
If you can think of anything else which is involved in upgrade of OODT --> 0.10 then please let me know.
Ta
