### PR TITLE
Enable use of OODT SNAPSHOT's in DRAT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <oodt.version>0.10</oodt.version>
+    <oodt.version>0.11-SNAPSHOT</oodt.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Hi @karanjeets @chrismattmann this is a trivial update to enable use of nightly SNAPSHOT's for OODT. The SNAPSHOT's generated from trunk build on builds.apache.org are now the only SNAPSHOT artifacts being published therefore we should always be good to keep DRAT running with most up-to-date code. 
