### PR TITLE
Upgrade to RAT 0.12

### DIFF
--- a/rat/pom.xml
+++ b/rat/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.apache.rat</groupId>
       <artifactId>apache-rat</artifactId>
-      <version>0.11</version>
+      <version>0.12</version>
     </dependency>  
   </dependencies>
 


### PR DESCRIPTION
As we discussed in Vancouver @karanjeets, RAT 0.12 has been recently released: https://lists.apache.org/thread.html/7c2dbdbb5f49a04025a1645cf01c34405fc8dc4979af86c12b9da9d8@%3Cannounce.apache.org%3E
