### PR TITLE
Fix for Solr failing to start on Ubuntu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <oodt.version>1.2</oodt.version>
+    <oodt.version>1.2.1</oodt.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Upgrading OODT to 1.2.1 fixed the problem.