### PR TITLE
Streamline usage of junit among the project and add Travis CI build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+
+#before_script:
+#  - pip install --user codecov
+
+#after_success:
+#  - codecov
+
+#addons:
+#  srcclr: true 

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>${junit.version}</version>
     </dependency>
   </dependencies>
 

--- a/filemgr/pom.xml
+++ b/filemgr/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pcs/pom.xml
+++ b/pcs/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <oodt.version>1.2.2</oodt.version>
+    <junit.version>4.12.</junit.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <oodt.version>1.2.2</oodt.version>
-    <junit.version>4.12.</junit.version>
+    <junit.version>4.12</junit.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
   </distributionManagement>
 
   <build>
+    <defaultGoal>clean install</defaultGoal>
     <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
     <testSourceDirectory>${basedir}/src/test</testSourceDirectory>
     <plugins>

--- a/proteus/pom.xml
+++ b/proteus/pom.xml
@@ -180,8 +180,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>UTF-8</encoding>
 					<showWarnings>true</showWarnings>
 					<showDeprecation>true</showDeprecation>

--- a/proteus/pom.xml
+++ b/proteus/pom.xml
@@ -39,7 +39,6 @@
 	</licenses>
 	<properties>
 		<wicket.version>7.8.0</wicket.version>
-		<junit.version>4.12</junit.version>
 		<log4j.version>2.3</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cxf.version>2.2.3</cxf.version>

--- a/resmgr/pom.xml
+++ b/resmgr/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
The project uses various junit versions - 
the next step would be to define them in the parent-pom.