### PR TITLE
Fix security vulnerabilities in proteus and webapps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,6 @@ You can clone the wiki by running
 
 Visit our new website [drat.apache.org](https://drat.apache.org/) at the [Apache Software Foundation](https://www.apache.org/).
 
+---
+
 Current build status: [![Build Status](https://travis-ci.org/apache/drat.svg?branch=master)](https://travis-ci.org/apache/drat)

--- a/proteus/pom.xml
+++ b/proteus/pom.xml
@@ -29,7 +29,7 @@
         <name>DRAT Proteus</name>
         <artifactId>dms-proteus</artifactId>
         <packaging>war</packaging>
-        <description></description>
+        <description/>
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
@@ -38,8 +38,8 @@
 		</license>
 	</licenses>
 	<properties>
-		<wicket.version>7.8.0</wicket.version>
-		<log4j.version>2.3</log4j.version>
+		<wicket.version>8.0.0</wicket.version>
+		<log4j.version>2.8.2</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cxf.version>2.2.3</cxf.version>
         <!-- allowed values: R7, 1.0, 1.5, 2.0 or none -->
@@ -75,13 +75,13 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-client</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.16</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-hc</artifactId>
             <!-- 2.7.8 or 3.0.0-milestone1 -->
-            <version>3.1.2</version>
+            <version>3.1.16</version>
         </dependency>
         <dependency>
             <groupId>org.wicketstuff</groupId>

--- a/webapps/solr-webapp/pom.xml
+++ b/webapps/solr-webapp/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr</artifactId>
-      <version>4.2.1</version>
+      <version>4.7.0</version>
       <type>war</type>
     </dependency>
 


### PR DESCRIPTION
Independent of the updates I have local test failures:
` Tests in error: 
  TestProcessDratWrapper.testParseWorkflows:29 ExceptionInInitializer
  TestProcessDratWrapper.testIsRunning:79 NoClassDefFound Could not initialize c...
  TestProcessDratWrapper.testFilterMappers:59 NoClassDefFound Could not initiali...
  TestProcessDratWrapper.testStillRunning:42 NoClassDefFound Could not initializ...
`

Even reverting the version updates yields test failures, therefore I put the pull request in for merging.