### PR TITLE
[Security] Fix downloading SNAPSHOTs from ASF via https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshots</name>
-      <url>http://repository.apache.org/snapshots/</url>
+      <url>https://repository.apache.org/snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
There was just an incoming security mail ....
I'm not sure if we need the other repository as it's http only as well.

Fixes:
CWE-829: Inclusion of Functionality from Untrusted Control Sphere
CWE-494: Download of Code Without Integrity Check