### PR TITLE
Vue.js DRAT proxy to develop the UI remote from the server

### DIFF
--- a/webapps/proteus-new/src/main/webapp/resources/.env.development
+++ b/webapps/proteus-new/src/main/webapp/resources/.env.development
@@ -1,0 +1,1 @@
+VUE_APP_ROOT_API=http://drat-vm.apache.org:8080

--- a/webapps/proteus-new/src/main/webapp/resources/package-lock.json
+++ b/webapps/proteus-new/src/main/webapp/resources/package-lock.json
@@ -4970,12 +4970,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4990,17 +4992,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5117,7 +5122,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5129,6 +5135,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5143,6 +5150,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5150,12 +5158,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5174,6 +5184,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5254,7 +5265,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5266,6 +5278,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5387,6 +5400,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/webapps/proteus-new/src/main/webapp/resources/vue.config.js
+++ b/webapps/proteus-new/src/main/webapp/resources/vue.config.js
@@ -1,3 +1,15 @@
 module.exports = {
-	baseUrl: './'
-}
+  publicPath: './',
+  devServer: {
+    proxy: {
+      '/proteus': {
+        target: process.env.VUE_APP_ROOT_API,
+        changeOrigin: true
+      },
+      '/solr': {
+        target: process.env.VUE_APP_ROOT_API,
+        changeOrigin: true
+      }
+    }
+  }
+};


### PR DESCRIPTION
The UI devs might find it easier to develop without having to spin up a Java server in some cases.