### PR TITLE
Updated DRAT to work with OODT 1.9.1

### DIFF
--- a/pge/src/main/resources/config/PgeConfig_MimePartitioner.xml
+++ b/pge/src/main/resources/config/PgeConfig_MimePartitioner.xml
@@ -8,7 +8,7 @@
      <cmd>echo "Creating working dirs"</cmd>
      <cmd>mkdir [JobInputDir] ; mkdir [JobOutputDir]; mkdir [JobLogDir]</cmd>
      <cmd>echo "Running MIME partitioner"</cmd>
-     <cmd>[MimePartitionerPyScript] -u [SolrUrl] -c [NumFilesPerJob] -w [PCS_WorkflowManagerUrl] -t [RatTaskId] > [JobLogDir]/mime-partitioner-[DateMilis].log</cmd>
+     <cmd>[PythonExecutable] [MimePartitionerPyScript] -u [SolrUrl] -c [NumFilesPerJob] -w [PCS_WorkflowManagerUrl] -t [RatTaskId] > [JobLogDir]/mime-partitioner-[DateMilis].log</cmd>
   </exe>
 
   <!-- Files to ingest -->

--- a/pge/src/main/resources/config/PgeConfig_RatAggregator.xml
+++ b/pge/src/main/resources/config/PgeConfig_RatAggregator.xml
@@ -8,7 +8,7 @@
      <cmd>echo "Creating working dirs"</cmd>
      <cmd>mkdir [JobInputDir] ; mkdir [JobOutputDir]; mkdir [JobLogDir]</cmd>
      <cmd>echo "Running RAT aggregator"</cmd>
-     <cmd>[RatAggregatorScript] `python -c "print(' '.join('[InputFiles]'.split(',')))"` > [JobOutputDir]/rat_aggregate_stats_[DateMilis].csv</cmd>
+     <cmd>[PythonExecutable] [RatAggregatorScript] `python -c "print(' '.join('[InputFiles]'.split(',')))"` > [JobOutputDir]/rat_aggregate_stats_[DateMilis].csv</cmd>
   </exe>
 
   <!-- Files to ingest -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <oodt.version>1.9</oodt.version>
+    <oodt.version>1.10-SNAPSHOT</oodt.version>
     <junit.version>4.12</junit.version>
   </properties>
 

--- a/resmgr/src/main/resources/bin/resmgr
+++ b/resmgr/src/main/resources/bin/resmgr
@@ -91,7 +91,7 @@ if [ "$1" = "start" ]; then
     -Djava.util.logging.config.file="$RESMGR_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.resource.properties="$RESMGR_HOME"/etc/resource.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \
-    org.apache.oodt.cas.resource.system.XmlRpcResourceManager \
+    org.apache.oodt.cas.resource.system.ResourceManagerMain \
     --portNum "$RESMGR_PORT" 2>&1 &
 
   if [ ! -z "$RESMGR_PID" ]; then

--- a/workflow/src/main/resources/bin/wmgr-client
+++ b/workflow/src/main/resources/bin/wmgr-client
@@ -72,4 +72,4 @@ cd "$WORKFLOW_HOME"/bin
   -Djava.util.logging.config.file="$WORKFLOW_HOME"/etc/logging.properties \
   -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$WORKFLOW_HOME"/policy/cmd-line-actions.xml \
   -Dorg.apache.oodt.cas.cli.option.spring.config=file:"$WORKFLOW_HOME"/policy/cmd-line-options.xml \
-  org.apache.oodt.cas.workflow.system.XmlRpcWorkflowManagerClient "$@"
+  org.apache.oodt.cas.workflow.system.WorkflowManagerClientStarter "$@"

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -48,6 +48,7 @@
 	      <property name="SolrUrl" value="http://localhost:8080/solr/drat"/>
           <property name="RatTaskId" value="urn:drat:RatCodeAudit"/>
           <property name="NumFilesPerJob" value="100"/>
+          <property name="PythonExecutable" value="python3"/>
           <property name="MimePartitionerPyScript" value="[DRAT_HOME]/pge/bin/mime_partitioner/mime_rat_partitioner.py"/>
           <requiredMetFields/>
     </configuration>
@@ -70,6 +71,7 @@
           <property name="PCS_FileManagerUrl"     value="[FILEMGR_URL]" envReplace="true"/>
           <property name="PCS_MetFileExtension" value="met"/>
           <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory"/>
+          <property name="PythonExecutable" value="python3"/>
           <property name="RatAggregatorScript" value="[DRAT_HOME]/pge/bin/rat_aggregator/rat_aggregator.py"/>
           <requiredMetFields/>
     </configuration>


### PR DESCRIPTION
Updated the required scripts and fixed python version issue when executing rat aggregator and mime partitioner to be compatible with OODT 1.9.1 release (which is yet to be released).